### PR TITLE
Add keybind for wireless fluid pattern terminal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     deobfCompile 'curse.maven:gregtech-ce-unofficial-557242:3784798' // gt
     deobfCompile 'curse.maven:ae2-extended-life-570458:5028606' //pae2
     deobfCompile 'curse.maven:dynamistics-383632:3056455' // dy
+    deobfCompile 'curse.maven:baubles-227083:2518667' //baubles
     compileOnly 'curse.maven:opencomputers-223008:4630537' //oc
     compileOnly "curse.maven:mekanism-ce-399904:4804509" //mek-ce
     compileOnly "curse.maven:ae-additions-extra-cells-2-fork-493962:3814371" //aeadditions

--- a/src/main/java/com/glodblock/github/client/KeyBindings.java
+++ b/src/main/java/com/glodblock/github/client/KeyBindings.java
@@ -1,0 +1,31 @@
+package com.glodblock.github.client;
+
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.network.CPacketUseKeybind;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.client.settings.KeyModifier;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.InputEvent;
+
+public class KeyBindings {
+
+    private static final String KEY_CATEGORY = "key.ae2fc.category";
+
+    private static final KeyBinding WIRELESS_FLUID_PATTERN_TERMINAL = new KeyBinding("key.ae2fc.open_wireless_fluid_pattern_terminal.desc", KeyConflictContext.UNIVERSAL, KeyModifier.NONE, 0, KEY_CATEGORY);
+
+    public static void init() {
+        ClientRegistry.registerKeyBinding(WIRELESS_FLUID_PATTERN_TERMINAL);
+        MinecraftForge.EVENT_BUS.register(KeyBindings.class);
+    }
+
+    @SubscribeEvent
+    public static void onKeyInputEvent(InputEvent.KeyInputEvent event) {
+        if (WIRELESS_FLUID_PATTERN_TERMINAL.isPressed()) {
+            FluidCraft.proxy.netHandler.sendToServer(new CPacketUseKeybind());
+        }
+    }
+
+}

--- a/src/main/java/com/glodblock/github/common/item/ItemWirelessFluidPatternTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemWirelessFluidPatternTerminal.java
@@ -13,9 +13,11 @@ import net.minecraft.world.World;
 
 public class ItemWirelessFluidPatternTerminal extends ToolWirelessTerminal {
 
+    private static final int OFFHAND_SLOT = 40;
+
     @Override
     public ActionResult<ItemStack> onItemRightClick(World w, EntityPlayer player, EnumHand hand) {
-        Util.openWirelessTerminal(player.getHeldItem(hand), hand == EnumHand.MAIN_HAND ? player.inventory.currentItem : 40, false, w, player, GuiType.WIRELESS_FLUID_PATTERN_TERMINAL);
+        Util.openWirelessTerminal(player.getHeldItem(hand), hand == EnumHand.MAIN_HAND ? player.inventory.currentItem : OFFHAND_SLOT, false, w, player, GuiType.WIRELESS_FLUID_PATTERN_TERMINAL);
         return new ActionResult<>(EnumActionResult.SUCCESS, player.getHeldItem(hand));
     }
 

--- a/src/main/java/com/glodblock/github/common/item/ItemWirelessFluidPatternTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemWirelessFluidPatternTerminal.java
@@ -15,7 +15,7 @@ public class ItemWirelessFluidPatternTerminal extends ToolWirelessTerminal {
 
     @Override
     public ActionResult<ItemStack> onItemRightClick(World w, EntityPlayer player, EnumHand hand) {
-        Util.openWirelessTerminal(player.getHeldItem(hand), hand, w, player, GuiType.WIRELESS_FLUID_PATTERN_TERMINAL);
+        Util.openWirelessTerminal(player.getHeldItem(hand), hand == EnumHand.MAIN_HAND ? player.inventory.currentItem : 40, false, w, player, GuiType.WIRELESS_FLUID_PATTERN_TERMINAL);
         return new ActionResult<>(EnumActionResult.SUCCESS, player.getHeldItem(hand));
     }
 

--- a/src/main/java/com/glodblock/github/loader/ChannelLoader.java
+++ b/src/main/java/com/glodblock/github/loader/ChannelLoader.java
@@ -21,6 +21,7 @@ public class ChannelLoader implements Runnable {
         FluidCraft.proxy.netHandler.registerMessage(new CPacketPatternValueSet.Handler(), CPacketPatternValueSet.class, id ++, Side.SERVER);
         FluidCraft.proxy.netHandler.registerMessage(new CPacketInventoryAction.Handler(), CPacketInventoryAction.class, id ++, Side.SERVER);
         FluidCraft.proxy.netHandler.registerMessage(new SPacketSetItemAmount.Handler(), SPacketSetItemAmount.class, id ++, Side.CLIENT);
+        FluidCraft.proxy.netHandler.registerMessage(new CPacketUseKeybind.Handler(), CPacketUseKeybind.class, id ++, Side.SERVER);
     }
 
 }

--- a/src/main/java/com/glodblock/github/network/CPacketUseKeybind.java
+++ b/src/main/java/com/glodblock/github/network/CPacketUseKeybind.java
@@ -1,0 +1,60 @@
+package com.glodblock.github.network;
+
+import baubles.api.BaublesApi;
+import com.glodblock.github.inventory.GuiType;
+import com.glodblock.github.loader.FCItems;
+import com.glodblock.github.util.Util;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+
+public class CPacketUseKeybind implements IMessage {
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        // empty for now, can be changed to allow differentiating keybinds if more are added in the future
+    }
+
+    public static class Handler implements IMessageHandler<CPacketUseKeybind, IMessage> {
+
+        @Override
+        public IMessage onMessage(CPacketUseKeybind message, MessageContext ctx) {
+            final EntityPlayerMP player = ctx.getServerHandler().player;
+            player.getServerWorld().addScheduledTask(() -> {
+                for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
+                    ItemStack stackInSlot = player.inventory.getStackInSlot(i);
+                    if (stackInSlot.getItem() == FCItems.WIRELESS_FLUID_PATTERN_TERMINAL) {
+                        Util.openWirelessTerminal(stackInSlot, i, false, player.world, player, GuiType.WIRELESS_FLUID_PATTERN_TERMINAL);
+                        return;
+                    }
+                }
+                if (Loader.isModLoaded("baubles")) {
+                    tryOpenBauble(player);
+                }
+            });
+            return null;
+        }
+
+        @Optional.Method(modid = "baubles")
+        private static void tryOpenBauble(EntityPlayer player) {
+            for (int i = 0; i < BaublesApi.getBaublesHandler(player).getSlots(); i++) {
+                ItemStack stackInSlot = BaublesApi.getBaublesHandler(player).getStackInSlot(i);
+                if (stackInSlot.getItem() == FCItems.WIRELESS_FLUID_PATTERN_TERMINAL) {
+                    Util.openWirelessTerminal(stackInSlot, i, true, player.world, player, GuiType.WIRELESS_FLUID_PATTERN_TERMINAL);
+                    return;
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/glodblock/github/proxy/ClientProxy.java
+++ b/src/main/java/com/glodblock/github/proxy/ClientProxy.java
@@ -1,6 +1,7 @@
 package com.glodblock.github.proxy;
 
 import appeng.api.util.AEColor;
+import com.glodblock.github.client.KeyBindings;
 import com.glodblock.github.client.model.DenseEncodedPatternModel;
 import com.glodblock.github.client.render.DropColourHandler;
 import com.glodblock.github.client.render.RenderIngredientBuffer;
@@ -80,6 +81,7 @@ public class ClientProxy extends CommonProxy {
         Minecraft.getMinecraft().getItemColors().registerItemColorHandler(DenseEncodedPatternModel.PATTERN_ITEM_COLOR_HANDLER, FCItems.DENSE_ENCODED_PATTERN);
         Minecraft.getMinecraft().getItemColors().registerItemColorHandler(DenseEncodedPatternModel.PATTERN_ITEM_COLOR_HANDLER, FCItems.DENSE_CRAFT_ENCODED_PATTERN);
         Minecraft.getMinecraft().getItemColors().registerItemColorHandler(DenseEncodedPatternModel.PATTERN_ITEM_COLOR_HANDLER, FCItems.LARGE_ITEM_ENCODED_PATTERN);
+        KeyBindings.init();
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/util/Util.java
+++ b/src/main/java/com/glodblock/github/util/Util.java
@@ -375,7 +375,7 @@ public final class Util {
         }
     }
 
-    public static void openWirelessTerminal(ItemStack item, EnumHand hand, World w, EntityPlayer player, GuiType gui) {
+    public static void openWirelessTerminal(ItemStack item, int playerInvSlot, boolean isBaubleSlot, World w, EntityPlayer player, GuiType gui) {
         IWirelessTermRegistry registry = AEApi.instance().registries().wireless();
         if (Platform.isClient()) {
             return;
@@ -397,15 +397,7 @@ public final class Util {
             return;
         }
         if (handler.hasPower(player, 0.5, item)) {
-            int x, y;
-            if (player.openContainer instanceof IInventorySlotAware) {
-                x = ((IInventorySlotAware) player.openContainer).getInventorySlot();
-                y = ((IInventorySlotAware) player.openContainer).isBaubleSlot() ? 1 : 0;
-            } else {
-                x = player.inventory.currentItem;
-                y = 0;
-            }
-            InventoryHandler.openGui(player, w, new BlockPos(x, y, Integer.MIN_VALUE), EnumFacing.values()[hand.ordinal()], gui);
+            InventoryHandler.openGui(player, w, new BlockPos(playerInvSlot, isBaubleSlot ? 1 : 0, Integer.MIN_VALUE), EnumFacing.DOWN, gui);
         } else {
             player.sendMessage(PlayerMessages.DeviceNotPowered.get());
         }

--- a/src/main/resources/assets/ae2fc/lang/en_us.lang
+++ b/src/main/resources/assets/ae2fc/lang/en_us.lang
@@ -1,5 +1,8 @@
 itemGroup.ae2fc=AE2 Fluid Crafting
 
+key.ae2fc.category=AE2 Fluid Crafting
+key.ae2fc.open_wireless_fluid_pattern_terminal.desc=Open Wireless Fluid Pattern Terminal
+
 tile.ae2fc:fluid_discretizer.name=ME Fluid Discretizer
 tile.ae2fc:gas_discretizer.name=ME Gas Discretizer
 tile.ae2fc:fluid_pattern_encoder.name=Fluid Pattern Encoder


### PR DESCRIPTION
Pro gaming tip: never look at AE2's GUI handling. I have seen things I wish I could forget.

That aside the keybind works fine with or without Baubles and it's unmapped by default.
![image](https://github.com/AE2-UEL/AE2FluidCraft-Rework/assets/1492543/fc637556-73b5-49c0-8587-a2a55b44d176)