### PR TITLE
Add support for crafting lock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     deobfCompile 'curse.maven:modular-machinery-270790:2761302' // 1.11.1
     deobfCompile 'curse.maven:codechicken-lib-1-8-242818:2779848' //ccl
     deobfCompile 'curse.maven:gregtech-ce-unofficial-557242:3784798' // gt
-    deobfCompile 'curse.maven:ae2-extended-life-570458:5028606' //pae2
+    deobfCompile 'curse.maven:ae2-extended-life-570458:5147702' //pae2
     deobfCompile 'curse.maven:dynamistics-383632:3056455' // dy
     deobfCompile 'curse.maven:baubles-227083:2518667' //baubles
     compileOnly 'curse.maven:opencomputers-223008:4630537' //oc

--- a/src/main/java/com/glodblock/github/client/GuiItemDualInterface.java
+++ b/src/main/java/com/glodblock/github/client/GuiItemDualInterface.java
@@ -40,11 +40,11 @@ public class GuiItemDualInterface extends GuiInterface {
         ItemStack icon = AEApi.instance().definitions().blocks().fluidIface().maybeStack(1).orElse(ItemStack.EMPTY);
         switchInterface = new GuiTabButton(guiLeft + 133, guiTop, icon, icon.getDisplayName(), itemRender);
         buttonList.add(switchInterface);
-        fluidPacketBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 44, "SEND_MODE", "REAL_FLUID");
+        fluidPacketBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 62, "SEND_MODE", "REAL_FLUID");
         buttonList.add(fluidPacketBtn);
-        splittingBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 62, "SPLITTING", "ALLOW");
+        splittingBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 80, "SPLITTING", "ALLOW");
         buttonList.add(splittingBtn);
-        blockingBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 80, "BLOCK", "ALL");
+        blockingBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 98, "BLOCK", "ALL");
         buttonList.add(blockingBtn);
         priorityBtn = Ae2ReflectClient.getPriorityButton(this);
     }

--- a/src/main/java/com/glodblock/github/client/client/gui/GuiWrapInterface.java
+++ b/src/main/java/com/glodblock/github/client/client/gui/GuiWrapInterface.java
@@ -31,11 +31,11 @@ public class GuiWrapInterface extends GuiInterface {
     @Override
     protected void addButtons() {
         super.addButtons();
-        fluidPacketBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 44, "SEND_MODE", "REAL_FLUID");
+        fluidPacketBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 62, "SEND_MODE", "REAL_FLUID");
         buttonList.add(fluidPacketBtn);
-        splittingBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 62, "SPLITTING", "ALLOW");
+        splittingBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 80, "SPLITTING", "ALLOW");
         buttonList.add(splittingBtn);
-        blockingBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 80, "BLOCK", "ALL");
+        blockingBtn = new GuiFCImgButton(this.guiLeft - 18, this.guiTop + 98, "BLOCK", "ALL");
         buttonList.add(blockingBtn);
     }
 

--- a/src/main/java/com/glodblock/github/common/block/BlockDualInterface.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockDualInterface.java
@@ -2,10 +2,12 @@ package com.glodblock.github.common.block;
 
 import appeng.api.util.IOrientable;
 import appeng.block.AEBaseTileBlock;
+import appeng.tile.misc.TileInterface;
 import appeng.util.Platform;
 import com.glodblock.github.common.tile.TileDualInterface;
 import com.glodblock.github.inventory.GuiType;
 import com.glodblock.github.inventory.InventoryHandler;
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyBool;
@@ -14,6 +16,7 @@ import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
@@ -82,4 +85,11 @@ public class BlockDualInterface extends AEBaseTileBlock {
         }
     }
 
+    @Override
+    public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos) {
+        TileEntity tileEntity = this.getTileEntity(worldIn, pos);
+        if (tileEntity instanceof TileDualInterface) {
+            ((TileDualInterface) tileEntity).getInterfaceDuality().updateRedstoneState();
+        }
+    }
 }

--- a/src/main/java/com/glodblock/github/common/part/PartDualInterface.java
+++ b/src/main/java/com/glodblock/github/common/part/PartDualInterface.java
@@ -14,6 +14,7 @@ import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartModel;
+import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.AECableType;
 import appeng.api.util.IConfigManager;
@@ -32,6 +33,7 @@ import appeng.util.inv.IInventoryDestination;
 import appeng.util.inv.InvOperation;
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.component.DualityDualInterface;
+import com.glodblock.github.common.item.fake.FakeFluids;
 import com.glodblock.github.interfaces.FCPriorityHost;
 import com.glodblock.github.inventory.GuiType;
 import com.glodblock.github.inventory.InventoryHandler;
@@ -170,6 +172,16 @@ public class PartDualInterface extends PartBasicState
     public void onChangeInventory(final IItemHandler inv, final int slot, final InvOperation mc,
                                   final ItemStack removedStack, final ItemStack newStack) {
         duality.onItemInventoryChange(inv, slot, mc, removedStack, newStack);
+    }
+
+    @Override
+    public void onStackReturnNetwork(IAEFluidStack stack) {
+        this.duality.getItemInterface().onStackReturnedToNetwork(FakeFluids.packFluid2AEDrops(stack));
+    }
+
+    @Override
+    public void onStackReturnNetwork(IAEItemStack stack) {
+        this.duality.getItemInterface().onStackReturnedToNetwork(stack);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/part/PartDualInterface.java
+++ b/src/main/java/com/glodblock/github/common/part/PartDualInterface.java
@@ -26,6 +26,7 @@ import appeng.helpers.Reflected;
 import appeng.items.parts.PartModels;
 import appeng.parts.PartBasicState;
 import appeng.parts.PartModel;
+import appeng.tile.misc.TileInterface;
 import appeng.util.Platform;
 import appeng.util.SettingsFrom;
 import appeng.util.inv.IAEAppEngInventory;
@@ -34,6 +35,7 @@ import appeng.util.inv.InvOperation;
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.component.DualityDualInterface;
 import com.glodblock.github.common.item.fake.FakeFluids;
+import com.glodblock.github.common.tile.TileDualInterface;
 import com.glodblock.github.interfaces.FCPriorityHost;
 import com.glodblock.github.inventory.GuiType;
 import com.glodblock.github.inventory.InventoryHandler;
@@ -47,7 +49,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.IItemHandler;
 
@@ -293,4 +297,11 @@ public class PartDualInterface extends PartBasicState
         }
     }
 
+    @Override
+    public void onNeighborChanged(IBlockAccess w, BlockPos pos, BlockPos neighbor) {
+        TileEntity tileEntity = getTileEntity();
+        if (tileEntity instanceof TileDualInterface) {
+            ((TileDualInterface) tileEntity).getInterfaceDuality().updateRedstoneState();
+        }
+    }
 }

--- a/src/main/java/com/glodblock/github/common/tile/TileDualInterface.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileDualInterface.java
@@ -12,6 +12,7 @@ import appeng.api.networking.events.MENetworkPowerStatusChange;
 import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
+import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEPartLocation;
@@ -27,6 +28,7 @@ import appeng.util.SettingsFrom;
 import appeng.util.inv.IInventoryDestination;
 import appeng.util.inv.InvOperation;
 import com.glodblock.github.common.component.DualityDualInterface;
+import com.glodblock.github.common.item.fake.FakeFluids;
 import com.glodblock.github.interfaces.FCPriorityHost;
 import com.glodblock.github.inventory.GuiType;
 import com.glodblock.github.loader.FCBlocks;
@@ -203,6 +205,16 @@ public class TileDualInterface extends AENetworkInvTile
     public void onChangeInventory(final IItemHandler inv, final int slot, final InvOperation mc,
                                   final ItemStack removed, final ItemStack added) {
         duality.onItemInventoryChange(inv, slot, mc, removed, added);
+    }
+
+    @Override
+    public void onStackReturnNetwork(IAEFluidStack stack) {
+        duality.getItemInterface().onStackReturnedToNetwork(FakeFluids.packFluid2AEDrops(stack));
+    }
+
+    @Override
+    public void onStackReturnNetwork(IAEItemStack stack) {
+        duality.getItemInterface().onStackReturnedToNetwork(stack);
     }
 
     @Override


### PR DESCRIPTION
resolve #150 

This patch uses a new interface definition and needs to wait for AE2-UEL/Applied-Energistics-2#423 to be merged before this PR can be merged.

这个补丁使用了新的接口定义，需要等待 上方的PR 合并

When compiling locally, the local new interface definition jar package is used. Need to modify the build script after AE2:UEL is released

本地编译时使用了本地jar 包，请在AE2:UEL发布后修改构建脚本中的CF文件ID 未包含构建脚本变更
